### PR TITLE
Minor changes to Makefile and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,15 @@
-obj/
-*.o
-*.exe
+*
+!*/
+
+# C/C++ files
+!*.c
+!*.h
+!*.cpp
+!*.hpp
+
+# Makefiles
+!*.mk
+!Makefile
+
+# Git-related files
+!.git*

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,17 @@
 SRC_DIR := src
 OBJ_DIR := obj
 
+TARGET := minesweeper.exe
+
 SRC_FILES := $(wildcard $(SRC_DIR)/*.cpp)
 OBJ_FILES := $(patsubst src/%.cpp, obj/%.o, $(SRC_FILES))
 
 CC := g++
 CFLAGS = -Wall -m64
 
-all: minesweeper.exe
+all: $(TARGET)
 
-minesweeper.exe: $(OBJ_FILES)
+$(TARGET): $(OBJ_FILES)
 	$(CC) $(CFLAGS) -o $@ $^
 	
 obj/%.o: src/%.cpp


### PR DESCRIPTION
I renamed `makefile` to `Makefile`. While yes, GNU Make looks for the makefile in this order...:
1. `GNUMakefile`
2. `makefile`
3. `Makefile`

...I've seen most people (including myself) use the "Makefile" name.

I also added a `TARGET` macro to the Makefile. This makes it easier to change the name (and path) of your output binary.

One other thing I did, was change the `.gitignore` file. Rather than it being a blacklist, it's now a whitelist.

-- Brynden "Gigabyte Giant" Bielefeld (brynden.bielefeld@hotmail.com)
